### PR TITLE
CIが通るようにパスを修正した

### DIFF
--- a/test/controllers/welcome_controller_test.rb
+++ b/test/controllers/welcome_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class WelcomeControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get welcome_index_url
+    get root_path
     assert_response :success
   end
 


### PR DESCRIPTION
手元でForkしていたのでプルリクにしてみました


- [\[Solved\]\-uninitialized constant Faraday::Error::ConnectionFailed in elastic\-search\-ruby](https://www.appsloveworld.com/ruby/100/350/uninitialized-constant-faradayerrorconnectionfailed-in-elastic-search)
- [RailsのDeleteメソッドでuninitialized constant Faraday::Error::ConnectionFailed \- Qiita](https://qiita.com/maztak/items/1c0633130ccc763a6486)

Faradayのエラーはelasticsearch関連っぽいので明日以降に直りそうですね。